### PR TITLE
Bump `markdown-to-jsx` >= `7.3.0`

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -54,7 +54,7 @@
     "@emotion/react": "^11.10.8",
     "@emotion/styled": "^11.10.8",
     "@mui/material": "^5.12.2",
-    "markdown-to-jsx": "^7.1.6",
+    "markdown-to-jsx": "^7.3.0",
     "react": ">= 17.0.2",
     "react-dom": ">= 17.0.2"
   },
@@ -76,7 +76,7 @@
     "@types/node": "^16.18.25",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.1",
-    "markdown-to-jsx": "^7.2.1",
+    "markdown-to-jsx": "^7.3.0",
     "postcss-import": "^15.1.0",
     "postcss-preset-env": "^8.2.0",
     "prism-react-renderer": "^2.0.3",


### PR DESCRIPTION
Bumping to version `7.3.0` of `markdown-to-jsx`, which fixes a bug regarding import statements being used outside of modules. This was originally reported under #9 (but closed due to being a `markdown-to-jsx` issue and not a `mui-markdown` issue).

See the released version (https://github.com/probablyup/markdown-to-jsx/releases/tag/v7.3.0) which includes the patch for the bug (https://github.com/probablyup/markdown-to-jsx/pull/500).